### PR TITLE
Support new RM4 devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Connect your Android device to your computer and browse the SD card/External Sto
 
 ## Configuring node-red nodes
 
-Assuming you have added the Broadlink nodes and configured as above, you will need the MAC address of the device, IP address and the path to the SharedData folder above.
+Assuming you have added the Broadlink nodes and configured as above, you will need the MAC address of the device, IP address and the path to the SharedData folder above. For device type, if you are having older device you can let default value `272a`. Newer devices like new RM3 or RM4 have to put correct device type. You can find your device type via discover node.
 
 1. Add the RM node and double click it
 2. Select device and `add new rmdevice`
-3. Fill in the MAC address of the device, IP address and the full path to the SharedData folder in the `Catalog` field and click `Add`
+3. Fill in the MAC address of the device, IP address, device type and the full path to the SharedData folder in the `Catalog` field and click `Add`
 4. You will then need to save the node and click `Deploy` so that you can see the buttons you created in the Broadlink app in the node.
 5. Double click on the node again and you should be now able to select Action -> Send and then pick the remote and button you wish to send.
 6. Save node, add an inject node on the front and link them together and deploy.

--- a/examples/Learn and send data.json
+++ b/examples/Learn and send data.json
@@ -152,6 +152,7 @@
         "z": "",
         "folder": "D:/SharedData",
         "mac": "b4430dc30cb3",
+        "devType":"272a",
         "host": "192.168.31.14"
     }
 ]

--- a/nodes/A1.js
+++ b/nodes/A1.js
@@ -1,7 +1,7 @@
 ﻿var Device = require("./Device.js");
 class A1 extends Device {
-    constructor(host, mac, timeout = 10) {
-        super(host, mac, timeout);
+    constructor(host, mac, devType = "272a", timeout = 10) {
+        super(host, mac, devType, timeout);
 
         this.on("payload", (err, payload) => {
             var param = payload[0];

--- a/nodes/Constants.js
+++ b/nodes/Constants.js
@@ -1,0 +1,3 @@
+module.exports = Object.freeze({
+    RM4: ['51da', '5f36', '610f', '610e', '62be']
+});

--- a/nodes/Device.js
+++ b/nodes/Device.js
@@ -3,10 +3,10 @@ let dgram = require('dgram');
 let os = require('os');
 let crypto = require('crypto');
 class Device {
-    constructor(host, mac, type, timeout = 10) {
+    constructor(host, mac, devType, timeout = 10) {
         this.host = host;
         this.mac = mac;
-        this.type = type;
+        this.devType = devType;
         this.emitter = new EventEmitter();
 
         this.on = this.emitter.on;
@@ -68,8 +68,8 @@ class Device {
         packet[0x05] = 0xa5;
         packet[0x06] = 0xaa;
         packet[0x07] = 0x55;
-        packet[0x24] = this.type & 0xff;
-        packet[0x25] = this.type >> 8;
+        packet[0x24] = this.devType & 0xff;
+        packet[0x25] = this.devType >> 8;
         packet[0x26] = command;
         packet[0x28] = this.count & 0xff;
         packet[0x29] = this.count >> 8;

--- a/nodes/Device.js
+++ b/nodes/Device.js
@@ -1,11 +1,12 @@
-﻿let EventEmitter = require('events');
+let EventEmitter = require('events');
 let dgram = require('dgram');
 let os = require('os');
 let crypto = require('crypto');
 class Device {
-    constructor(host, mac, timeout = 10) {
+    constructor(host, mac, type, timeout = 10) {
         this.host = host;
         this.mac = mac;
+        this.type = type;
         this.emitter = new EventEmitter();
 
         this.on = this.emitter.on;
@@ -67,8 +68,8 @@ class Device {
         packet[0x05] = 0xa5;
         packet[0x06] = 0xaa;
         packet[0x07] = 0x55;
-        packet[0x24] = 0x2a;
-        packet[0x25] = 0x27;
+        packet[0x24] = this.type & 0xff;
+        packet[0x25] = this.type >> 8;
         packet[0x26] = command;
         packet[0x28] = this.count & 0xff;
         packet[0x29] = this.count >> 8;

--- a/nodes/MP1.js
+++ b/nodes/MP1.js
@@ -1,7 +1,7 @@
 ﻿var Device = require("./Device.js");
 class MP1 extends Device {
-    constructor(host, mac, timeout = 10) {
-        super(host, mac, timeout);
+    constructor(host, mac, devType = "272a", timeout = 10) {
+        super(host, mac, devType, timeout);
 
         this.on("payload", (err, payload) => {
             var result = {

--- a/nodes/RM.js
+++ b/nodes/RM.js
@@ -1,7 +1,8 @@
 ﻿var Device = require("./Device.js");
+var constants = require('./Constants.js');
 class RM extends Device {
-    constructor(host, mac, timeout = 10) {
-        super(host, mac, timeout);
+    constructor(host, mac, type, timeout = 10) {
+        super(host, mac, type, timeout);
 
         this.on("payload", (err, payload) => {
             var param = payload[0];
@@ -48,24 +49,47 @@ class RM extends Device {
 
     checkTemperature() {
         var packet = Buffer.alloc(16, 0);
-        packet[0] = 1;
+        if (constants.RM4.indexOf(this.type) > -1) {
+            packet[0] = 4;
+            packet[1] = 0;
+            packet[2] = 1;
+        } else {
+            packet[0] = 1;
+        }
         this.sendPacket(0x6a, packet);
     }
 
 
     enterLearning() {
         var packet = Buffer.alloc(16, 0);
-        packet[0] = 3;
+        if (constants.RM4.indexOf(this.type) > -1) {
+            packet[0] = 4;
+            packet[1] = 0;
+            packet[2] = 3;
+        } else {
+            packet[0] = 3;    
+        }
         this.sendPacket(0x6a, packet);
     }
     checkData() {
         var packet = Buffer.alloc(16, 0);
-        packet[0] = 4;
+        if (constants.RM4.indexOf(this.type) > -1) {
+            packet[0] = 4;
+            packet[1] = 0;
+            packet[2] = 4;
+        } else {
+            packet[0] = 4;
+        }
         this.sendPacket(0x6a, packet);
     }
 
     sendData(data) {
-        var packet = new Buffer([0x02, 0x00, 0x00, 0x00]);
+        var packet;
+        if (constants.RM4.indexOf(this.type) > -1) {
+            packet = new Buffer([0xd0, 0x00, 0x02, 0x00, 0x00, 0x00]);
+        } else {
+            packet = new Buffer([0x02, 0x00, 0x00, 0x00]);
+        }
         packet = Buffer.concat([packet, data]);
         this.sendPacket(0x6a, packet);
     }

--- a/nodes/RM.js
+++ b/nodes/RM.js
@@ -1,10 +1,13 @@
 ﻿var Device = require("./Device.js");
 var constants = require('./Constants.js');
 class RM extends Device {
-    constructor(host, mac, type, timeout = 10) {
-        super(host, mac, type, timeout);
+    constructor(host, mac, devType, timeout = 10) {
+        super(host, mac, devType, timeout);
 
         this.on("payload", (err, payload) => {
+            if (constants.RM4.indexOf(devType) > -1) {
+                payload.copy(payload, 0, 2);
+            }
             var param = payload[0];
             switch (param) {
                 case 1:
@@ -49,7 +52,7 @@ class RM extends Device {
 
     checkTemperature() {
         var packet = Buffer.alloc(16, 0);
-        if (constants.RM4.indexOf(this.type) > -1) {
+        if (constants.RM4.indexOf(this.devType) > -1) {
             packet[0] = 4;
             packet[1] = 0;
             packet[2] = 1;
@@ -62,7 +65,7 @@ class RM extends Device {
 
     enterLearning() {
         var packet = Buffer.alloc(16, 0);
-        if (constants.RM4.indexOf(this.type) > -1) {
+        if (constants.RM4.indexOf(this.devType) > -1) {
             packet[0] = 4;
             packet[1] = 0;
             packet[2] = 3;
@@ -72,8 +75,9 @@ class RM extends Device {
         this.sendPacket(0x6a, packet);
     }
     checkData() {
+        console.log('checkdata');
         var packet = Buffer.alloc(16, 0);
-        if (constants.RM4.indexOf(this.type) > -1) {
+        if (constants.RM4.indexOf(this.devType) > -1) {
             packet[0] = 4;
             packet[1] = 0;
             packet[2] = 4;
@@ -85,7 +89,7 @@ class RM extends Device {
 
     sendData(data) {
         var packet;
-        if (constants.RM4.indexOf(this.type) > -1) {
+        if (constants.RM4.indexOf(this.devType) > -1) {
             packet = new Buffer([0xd0, 0x00, 0x02, 0x00, 0x00, 0x00]);
         } else {
             packet = new Buffer([0x02, 0x00, 0x00, 0x00]);

--- a/nodes/RM.js
+++ b/nodes/RM.js
@@ -75,7 +75,6 @@ class RM extends Device {
         this.sendPacket(0x6a, packet);
     }
     checkData() {
-        console.log('checkdata');
         var packet = Buffer.alloc(16, 0);
         if (constants.RM4.indexOf(this.devType) > -1) {
             packet[0] = 4;

--- a/nodes/RMNode.html
+++ b/nodes/RMNode.html
@@ -4,7 +4,8 @@
         defaults: {
             folder: { value: "", required: true, validate: RED.validators.regex(/^((?:[A-Z]:)?(?:\/.+$))/) },
             mac: { value: "", required: true, validate: RED.validators.regex(/^([0-9A-Fa-f]{12})$/) },
-            host: { value: "", required: true, validate: RED.validators.regex(/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/) }
+            host: { value: "", required: true, validate: RED.validators.regex(/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/) },
+            type: { value: "272a", required: true, validate: RED.validators.regex(/^([0-9A-Fa-f]{4})$/) }
         },
         label: function () {
             return this.mac.match(/[0-9A-Fa-f]{2}/g).join(':');
@@ -19,6 +20,10 @@
     <div class="form-row">
         <label for="node-config-input-host"><i class="fa fa-cog"></i> <span data-i18n="rm.label.host"></span></label>
         <input type="text" id="node-config-input-host" data-i18n="[placeholder]rm.placeholder.host">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-type"><i class="fa fa-cog"></i> <span data-i18n="rm.label.type"></span></label>
+        <input type="text" id="node-config-input-type" data-i18n="[placeholder]rm.placeholder.type">
     </div>
     <div class="form-row">
         <label for="node-config-input-folder"><i class="fa fa-database"></i> <span data-i18n="rm.label.folder"></span></label>

--- a/nodes/RMNode.html
+++ b/nodes/RMNode.html
@@ -35,6 +35,7 @@
 </script>
 <script type="text/x-red" data-help-name="rmdevice" data-lang="en-US">
     <p><span>Copy the directory <code>/sdcard/broadlink/eControl/</code> from your Android device, and specify the path to it in the <code>Catalog</code> field. In the <code>SharedData</code> directory there should be files named <code>jsonSubIr</code>,<code>jsonButton</code> and <code>jsonIrCode</code> If they do not exist, then it is possible to tap "Share" in the eControl app and "Share with other smartphones in the WI-FI network." After that, the files should appear.</span></p>
+    <p><span>For device type, if you are having older device you can let default value <code>272a</code>. Newer devices like new RM3 or RM4 have to put correct device type. You can find your device type via discover node.</span></p>
 </script>
 
 <script type="text/javascript">

--- a/nodes/RMNode.html
+++ b/nodes/RMNode.html
@@ -5,7 +5,7 @@
             folder: { value: "", required: true, validate: RED.validators.regex(/^((?:[A-Z]:)?(?:\/.+$))/) },
             mac: { value: "", required: true, validate: RED.validators.regex(/^([0-9A-Fa-f]{12})$/) },
             host: { value: "", required: true, validate: RED.validators.regex(/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/) },
-            type: { value: "272a", required: true, validate: RED.validators.regex(/^([0-9A-Fa-f]{4})$/) }
+            devType: { value: "272a", required: true, validate: RED.validators.regex(/^([0-9A-Fa-f]{4})$/) }
         },
         label: function () {
             return this.mac.match(/[0-9A-Fa-f]{2}/g).join(':');
@@ -22,8 +22,8 @@
         <input type="text" id="node-config-input-host" data-i18n="[placeholder]rm.placeholder.host">
     </div>
     <div class="form-row">
-        <label for="node-config-input-type"><i class="fa fa-cog"></i> <span data-i18n="rm.label.type"></span></label>
-        <input type="text" id="node-config-input-type" data-i18n="[placeholder]rm.placeholder.type">
+        <label for="node-config-input-devType"><i class="fa fa-cog"></i> <span data-i18n="rm.label.devType"></span></label>
+        <input type="text" id="node-config-input-devType" data-i18n="[placeholder]rm.placeholder.devType">
     </div>
     <div class="form-row">
         <label for="node-config-input-folder"><i class="fa fa-database"></i> <span data-i18n="rm.label.folder"></span></label>

--- a/nodes/RMNode.js
+++ b/nodes/RMNode.js
@@ -4,7 +4,7 @@
         RED.nodes.createNode(this, n);
         this.mac = n.mac.match(/[0-9A-Fa-f]{2}/g) != null ? new Buffer(n.mac.match(/[0-9A-Fa-f]{2}/g).map(function (num) { return parseInt(num, 16); })) : null;
         this.host = n.host;
-        this.type = n.type;
+        this.devType = n.devType;
         this.folder = n.folder;
 
         //var node = this;
@@ -24,10 +24,10 @@
             var conf = RED.nodes.getNode(config.device);
             var _device;
             if (conf != null && conf != undefined && conf != "") {
-                var _device = new RM({ address: conf.host, port: 80 }, conf.mac, conf.type);
+                var _device = new RM({ address: conf.host, port: 80 }, conf.mac, conf.devType);
             }
             else {
-                var _device = new RM({ address: msg.payload.host, port: 80 }, new Buffer(msg.payload.mac.replace(':', '').replace('-', '').match(/[0-9A-Fa-f]{2}/g).map(function (num) { return parseInt(num, 16); })), msg.payload.type);
+                var _device = new RM({ address: msg.payload.host, port: 80 }, new Buffer(msg.payload.mac.replace(':', '').replace('-', '').match(/[0-9A-Fa-f]{2}/g).map(function (num) { return parseInt(num, 16); })), msg.payload.devType);
             }
             // --- Fix for UDP ports not being closed
             setTimeout( function() {

--- a/nodes/RMNode.js
+++ b/nodes/RMNode.js
@@ -4,6 +4,7 @@
         RED.nodes.createNode(this, n);
         this.mac = n.mac.match(/[0-9A-Fa-f]{2}/g) != null ? new Buffer(n.mac.match(/[0-9A-Fa-f]{2}/g).map(function (num) { return parseInt(num, 16); })) : null;
         this.host = n.host;
+        this.type = n.type;
         this.folder = n.folder;
 
         //var node = this;
@@ -23,10 +24,10 @@
             var conf = RED.nodes.getNode(config.device);
             var _device;
             if (conf != null && conf != undefined && conf != "") {
-                var _device = new RM({ address: conf.host, port: 80 }, conf.mac);
+                var _device = new RM({ address: conf.host, port: 80 }, conf.mac, conf.type);
             }
             else {
-                var _device = new RM({ address: msg.payload.host, port: 80 }, new Buffer(msg.payload.mac.replace(':', '').replace('-', '').match(/[0-9A-Fa-f]{2}/g).map(function (num) { return parseInt(num, 16); })));
+                var _device = new RM({ address: msg.payload.host, port: 80 }, new Buffer(msg.payload.mac.replace(':', '').replace('-', '').match(/[0-9A-Fa-f]{2}/g).map(function (num) { return parseInt(num, 16); })), msg.payload.type);
             }
             // --- Fix for UDP ports not being closed
             setTimeout( function() {

--- a/nodes/S1C.js
+++ b/nodes/S1C.js
@@ -1,8 +1,8 @@
 ﻿
 var Device = require("./Device.js");
 class S1C extends Device {
-    constructor(host, mac, timeout = 10) {
-        super(host, mac, timeout);
+    constructor(host, mac, devType = "272a",  timeout = 10) {
+        super(host, mac, devType, timeout);
 
         this.on("payload", (err, payload) => {
             var param = payload[0];

--- a/nodes/SP2.js
+++ b/nodes/SP2.js
@@ -2,8 +2,8 @@
 
 class SP2 extends Device {
   
-    constructor(host, mac, timeout = 10) {
-        super(host, mac, timeout);
+    constructor(host, mac, devType = "272a", timeout = 10) {
+        super(host, mac, devType, timeout);
 
         this.on("payload", (err, payload) => {
             var param = payload[0];

--- a/nodes/locales/en-US/RMNode.json
+++ b/nodes/locales/en-US/RMNode.json
@@ -3,7 +3,7 @@
     "label": {
       "device": "Device",
       "mac": "MAC",
-      "type": "Type",
+      "devType": "Type",
       "host": "IP Address",
       "loading": "Loading...",
       "name": "Name",
@@ -25,7 +25,7 @@
     "placeholder": {
       "folder": "D:/SharedData",
       "name": "Name",
-      "type": "272a",
+      "devType": "272a",
       "mac": "FFFFFFFFFFFF",
       "host": "192.168.10.2"
     },

--- a/nodes/locales/en-US/RMNode.json
+++ b/nodes/locales/en-US/RMNode.json
@@ -3,6 +3,7 @@
     "label": {
       "device": "Device",
       "mac": "MAC",
+      "type": "Type",
       "host": "IP Address",
       "loading": "Loading...",
       "name": "Name",
@@ -24,6 +25,7 @@
     "placeholder": {
       "folder": "D:/SharedData",
       "name": "Name",
+      "type": "272a",
       "mac": "FFFFFFFFFFFF",
       "host": "192.168.10.2"
     },

--- a/nodes/locales/ru-RU/RMNode.json
+++ b/nodes/locales/ru-RU/RMNode.json
@@ -4,6 +4,7 @@
       "device": "Устройство",
       "mac": "MAC адрес",
       "host": "IP адрес",
+      "type": "тип",
       "loading": "Поиск...",
       "folder": "Каталог",
       "name": "Имя",
@@ -24,6 +25,7 @@
     "placeholder": {
       "folder": "D:/SharedData",
       "name": "Имя",
+      "type": "272a",
       "mac": "FFFFFFFFFFFF",
       "host": "192.168.10.2"
     },

--- a/nodes/locales/ru-RU/RMNode.json
+++ b/nodes/locales/ru-RU/RMNode.json
@@ -4,7 +4,7 @@
       "device": "Устройство",
       "mac": "MAC адрес",
       "host": "IP адрес",
-      "type": "тип",
+      "devType": "тип",
       "loading": "Поиск...",
       "folder": "Каталог",
       "name": "Имя",
@@ -25,7 +25,7 @@
     "placeholder": {
       "folder": "D:/SharedData",
       "name": "Имя",
-      "type": "272a",
+      "devType": "272a",
       "mac": "FFFFFFFFFFFF",
       "host": "192.168.10.2"
     },


### PR DESCRIPTION
Still something missing.

> @deadly667 Create a PR in your fork pointing to this repo.
> 
> Also, the changes in the payload bytes 0x24 and 0x25 should be conditioned by device type, otherwise, the older devices won't work.
> 
> if (this.type == 0x5f36) {
>   packet[0x24] = this.type & 0xff;
>   packet[0x25] = this.type >> 8;
> } else {
>   packet[0x24] = 0x2A;
>   packet[0x25] = 0x27;
> }

Hm, Im not sure about it. This 24 and 25 bytes are for device type. You used  0x272A device type. Idea was to set "type" default value to 0x272A in RMNode.html:
```
defaults: {
            folder: { value: "", required: true, validate: RED.validators.regex(/^((?:[A-Z]:)?(?:\/.+$))/) },
            mac: { value: "", required: true, validate: RED.validators.regex(/^([0-9A-Fa-f]{12})$/) },
            host: { value: "", required: true, validate: RED.validators.regex(/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/) },
            type: { value: "272a", required: true, validate: RED.validators.regex(/^([0-9A-Fa-f]{4})$/) }
        },
```

In that case, older devices will work if they dont change type. Also, if they put their correct device type that will also work.

What do you think about this?